### PR TITLE
Enable lexical binding

### DIFF
--- a/evil-args.el
+++ b/evil-args.el
@@ -1,4 +1,4 @@
-;;; evil-args.el --- Motions and text objects for delimited arguments in Evil.
+;;; evil-args.el --- Motions and text objects for delimited arguments in Evil. -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2014 Connor Smith
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.
